### PR TITLE
Add Web Performance WG to W3C Groups

### DIFF
--- a/index.html
+++ b/index.html
@@ -448,6 +448,16 @@
               future Web of Things work can make use of networking parameters
               that may impact performance.
             </dd>
+            <dt>
+              <a href="https://www.w3.org/webperf/">Web Performance Working Group</a>
+            </dt>
+            <dd>
+              The Web Performance Working Group's scope of work includes user agent 
+              features and APIs to observe and improve aspects of application performance, 
+              such as measuring network and rendering performance, responsiveness and 
+              interactivity, memory and CPU use, application failures, and similar APIs 
+              and infrastructure to enable measurement and delivery of better user experience. 
+            </dd>
           </dl>
           <h3 id="external-coordination">
             External Organizations


### PR DESCRIPTION
There can be close coordination between the Web And Networks Interest group and Web Performance WG. Therefore added the latter in the W3C groups list. Fix #7