### PR TITLE
Editorial updates below the Scope section

### DIFF
--- a/index.html
+++ b/index.html
@@ -288,14 +288,14 @@
           <ul id="stakeholders">
             <li>Participation from various stakeholder communities, including
             browser vendors, media professionals, cloud providers, hardware and software
-            developers, telecom companies, cable operators, application
+            developers, telecommunications companies, cable operators, application
             developers, regulators, and users.
             </li>
             <li>Members of the Interest Group join relevant W3C Groups and
             drive the development of work items.
             </li>
             <li>Engagement and coordination with other organizations in the
-            Telecom, Media and Internet industry to recommend and coordinate
+            Telecommunications, Media and Internet industries to recommend and coordinate
             technical standards development and promote adherence to W3C and/or
             other standards.
             </li>
@@ -347,7 +347,7 @@
             The IG will, during its lifetime, undertake different activities
             that may proceed in parallel. No specific timeline has been
             identified at this point, but the various activities are intended
-            to be running for short periods of time (2-12 months), with the
+            to run for short periods of time (2-12 months), with the
             possibility of running a few iterations of them.
           </p>
         </div>
@@ -467,7 +467,7 @@
             </dt>
             <dd>
               The 3rd Generation Partnership Project (3GPP) unites
-              telecommunications standard development organizations (ARIB,
+              telecommunications standards development organizations (ARIB,
               ATIS, CCSA, ETSI, TSDSI, TTA, TTC), known as “Organizational
               Partners” and provides their members with a stable environment to
               produce the Reports and Specifications that define 3GPP


### PR DESCRIPTION
Mostly spelling out "telecommunications"